### PR TITLE
Fix_ansible_warning

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,5 +53,5 @@ katello_client_repos_to_update:
     enabled: false
 
 katello_client_cronjob: true
-katello_client_cronjob_hour: 5
-katello_client_cronjob_minute: 0
+katello_client_cronjob_hour: "5"
+katello_client_cronjob_minute: "0"


### PR DESCRIPTION
"int" value but ansible suggested "string" value in defaults/mail.yml

Here the warning:

TASK [pescobar.katello_client : Add cron job to execute katello-tracer-upload every day] *********************************************************************************************************************************************
[WARNING]: The value "0" (type int) was converted to "u'0'" (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
[WARNING]: The value "5" (type int) was converted to "u'5'" (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
...